### PR TITLE
add support for a jshint options via config.js file

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,0 +1,4 @@
+{
+	"options": {},
+	"globals": {}
+}


### PR DESCRIPTION
added config.js

options is an optional object of options which control the operation of JSHINT. Most of the options are booleans: They are all optional and have a default value of false.

globals is an object of global variables, with keys as names and a boolean value to determine if they are assignable.

{
    "options": {
        //add options here
    },
    "globals" {
        //add globals here
    }
}
