### PR TITLE
Async linting/.jshintrc config lookup

### DIFF
--- a/main.js
+++ b/main.js
@@ -12,7 +12,6 @@ define(function (require, exports, module) {
     var AppInit                 = brackets.getModule("utils/AppInit"),
         CodeInspection          = brackets.getModule("language/CodeInspection"),
         FileSystem              = brackets.getModule("filesystem/FileSystem"),
-        FileSystemError         = brackets.getModule("filesystem/FileSystemError"),
         FileUtils               = brackets.getModule("file/FileUtils"),
         ProjectManager          = brackets.getModule("project/ProjectManager"),
         DocumentManager         = brackets.getModule("document/DocumentManager"),


### PR DESCRIPTION
Fixes #47.

@cfjedimaster, this PR passes JSHint extension to use async-linting and implements .jshintrc lookup (only within project root). Please take a look and test, I will continue my testing as well. Thanks!
