### PR TITLE
Add support for per-file directive overrides.

### DIFF
--- a/main.js
+++ b/main.js
@@ -151,7 +151,7 @@ define(function (require, exports, module) {
         return function(cfg) {
 
             var bundle,
-                has = Object.prototype.hasOwnProperty.call.bind(Object),
+                has = Object.prototype.hasOwnProperty.call.bind(Object.prototype.hasOwnProperty),
                 overrides = cfg.options.overrides,
                 pattern;
 


### PR DESCRIPTION
JSHint has added support for overrides within .jshintrc file, as per jshint/jshint#1401.
Additional routine within the config loading procedure attempts to match this behaviour.
