### PR TITLE
Added support for jshint extends option

### DIFF
--- a/main.js
+++ b/main.js
@@ -130,7 +130,8 @@ define(function (require, exports, module) {
                 // jslints -> cli.js -> loadConfig -> if (config['extends'])...
                 var baseConfigResult = $.Deferred();
                 if (config.extends) {
-                    var baseConfigResult = _readConfig(dir, config.extends);
+                    var extendFile = FileSystem.getFileForPath(dir + config.extends);
+                    baseConfigResult = _readConfig(extendFile.parentPath, extendFile.name);
                     delete config.extends;
                 }
                 else {


### PR DESCRIPTION
Added the extends options according to: https://github.com/jshint/jshint/pull/1314
Implemented in the cli.js of the command line version of jshint in loadConfig on line 532:

```
  if (config['extends']) {
    var baseConfig = exports.loadConfig(path.resolve(config.dirname, config['extends']));
    config.globals = _.extend({}, baseConfig.globals, config.globals);
    _.defaults(config, baseConfig);
    delete config['extends'];
  }
```
