### PR TITLE
Fix #52. Scan entire file tree for config by default.

### DIFF
--- a/main.js
+++ b/main.js
@@ -66,8 +66,6 @@ define(function (require, exports, module) {
             config = defaultConfig;
         }
         
-        _scanProjectOnly = pm.get(PREF_SCAN_PROJECT_ONLY);
-        
         var resultJH = JSHINT(text, config.options, config.globals);
 
         if (!resultJH) {


### PR DESCRIPTION
Fix #52. Scan entire file tree for config.

Also, add jshint.scanProjectOnly extension pref. When set to `true` would only scan up to the project root. The default is `false` -- scan the entire tree up to the root.

In order to set the pref to limit the scan to project subtree, add the following to your brackets.json or to project's .brackets.json:

```
{
    "jshint.scanProjectOnly": true 
}
```

cc: @cfjedimaster
